### PR TITLE
Use CurrentPage instead of converting Model.Content

### DIFF
--- a/Src/lecoati.usky.ui/Views/Partials/uSkySlider.cshtml
+++ b/Src/lecoati.usky.ui/Views/Partials/uSkySlider.cshtml
@@ -5,7 +5,7 @@
     int height = 550;
     int width = 1140;
 
-    dynamic slider = @Model.Content.GetPropertyValue("slider");
+    var slider = CurrentPage.slider;
     var sliderHeight = !string.IsNullOrEmpty(slider.height.Value.ToString()) ? slider.height.Value : height;
     var sliderWidth = !string.IsNullOrEmpty(slider.width.Value.ToString()) ? slider.width.Value : width;
     


### PR DESCRIPTION
It is best practice to use CurrentPage which is DynamicPublishedContent rather than converting Model.Content to a dynamic variable
