### PR TITLE
Fix conflict with draggable in Umbraco 7.4

### DIFF
--- a/Src/lecoati.usky.ui/App_Plugins/Lecoati.uSky.Slider/lib/draggable.js
+++ b/Src/lecoati.usky.ui/App_Plugins/Lecoati.uSky.Slider/lib/draggable.js
@@ -1,5 +1,5 @@
 ﻿angular.module("umbraco").
-    directive('draggable', function () {
+    directive('uskyDraggable', function () {
         return {
             restrict: 'A',
             scope: {

--- a/Src/lecoati.usky.ui/App_Plugins/Lecoati.uSky.Slider/uSky.Slider.html
+++ b/Src/lecoati.usky.ui/App_Plugins/Lecoati.uSky.Slider/uSky.Slider.html
@@ -78,7 +78,7 @@
             <div id="slideFluid" class="layer-show" ng-style="setSliderStyle()">
 
                 <div class="slider-revolution-layer"
-                     draggable
+                     usky-draggable
                      ng-class="{ selected: layer == $parent.currentLayer , hover: layer == $parent.overLayer }"
                      aspectratio="layer.type=='image'"
                      resize="layer.type=='image'"


### PR DESCRIPTION
In Umbraco 7.4, the draggable directive conflicts with the media picker. This PR fixes that by simply renaming the directive to something a little less generic.