### PR TITLE
Draggable fix for Umbraco 7.10

### DIFF
--- a/Src/lecoati.usky.ui/App_Plugins/Lecoati.uSky.Slider/lib/draggable.js
+++ b/Src/lecoati.usky.ui/App_Plugins/Lecoati.uSky.Slider/lib/draggable.js
@@ -1,5 +1,5 @@
 ﻿angular.module("umbraco").
-    directive('draggable', function () {
+    directive('uskydraggable', function () {
         return {
             restrict: 'A',
             scope: {

--- a/Src/lecoati.usky.ui/App_Plugins/Lecoati.uSky.Slider/uSky.Slider.html
+++ b/Src/lecoati.usky.ui/App_Plugins/Lecoati.uSky.Slider/uSky.Slider.html
@@ -110,7 +110,7 @@
             <div id="slideFluid" class="layer-show" ng-style="setSliderStyle()">
 
                 <div class="slider-revolution-layer"
-                     draggable
+                     uskydraggable
                      ng-class="{ selected: layer == $parent.currentLayer , hover: layer == $parent.overLayer }"
                      aspectratio="layer.type=='image'"
                      resize="layer.type=='image'"


### PR DESCRIPTION
Due to a conflict with Umbraco 7.10 draggable name, uSkySlider draggable directive has been renamed. This fix the issue and both Umbraco Backend and uSkySlider work fine.